### PR TITLE
chore: rename IQAICOM/IQAIcom to IQOfficial

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pnpm dlx @iqai/mcp-iqwiki
 ### 🔧 Build from Source
 
 ```bash
-git clone https://github.com/IQAIcom/mcp-iqwiki.git
+git clone https://github.com/IQOfficial/mcp-iqwiki.git
 cd mcp-iqwiki
 pnpm install
 pnpm run build

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
 	"author": "IQAI",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/IQAIcom/mcp-iqwiki.git"
+		"url": "https://github.com/IQOfficial/mcp-iqwiki.git"
 	},
 	"license": "ISC",
-	"homepage": "https://github.com/IQAIcom/mcp-iqwiki",
+	"homepage": "https://github.com/IQOfficial/mcp-iqwiki",
 	"bugs": {
-		"url": "https://github.com/IQAIcom/mcp-iqwiki/issues"
+		"url": "https://github.com/IQOfficial/mcp-iqwiki/issues"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Renames `IQAICOM`, `IQAIcom`, and `iqaicom` references to `IQOfficial` / `iqofficial` (case-preserving) as part of the brand handle rename. Covers Twitter/X handles, GitHub URLs, Telegram links, package metadata, badges, and docs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>